### PR TITLE
Remove ssl block crawlers

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,6 +109,11 @@ def get_participant_from_hash():
     return None
 
 
+@app.route('/robots.txt')
+def robots():
+    return make_response(render_template('robots.txt'))
+
+
 @app.route('/')
 def index():
     # if request.cookies.get('first') is None:

--- a/app.py
+++ b/app.py
@@ -8,7 +8,6 @@ import hashlib
 import peewee
 from peewee import fn
 import jinja2
-from flask_sslify import SSLify
 from apscheduler.schedulers.background import BackgroundScheduler
 from flask_mail import Mail, Message
 from flask import Flask, render_template, request, make_response, flash, url_for, redirect
@@ -18,7 +17,6 @@ import forms
 # import users
 
 app = Flask(__name__)
-sslify = SSLify(app)
 
 try:
     import environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ click==7.1.2
 Flask==1.1.2
 Flask-Login==0.5.0
 Flask-Mail==0.9.1
-Flask-SSLify==0.1.5
 Flask-WTF==0.14.3
 gunicorn==20.0.4
 itsdangerous==1.1.0

--- a/templates/robots.txt
+++ b/templates/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
1. Remove auto redirecting of non-ssl traffic to https as there is no longer a valid ssl certificate
2. Add a robots.txt endpoint instructing crawlers not to index the site